### PR TITLE
F0-1176 Metrikkressurs import i config

### DIFF
--- a/src/main/java/no/nav/ApplicationConfig.java
+++ b/src/main/java/no/nav/ApplicationConfig.java
@@ -6,10 +6,9 @@ import no.nav.apiapp.config.ApiAppConfigurator;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import static no.nav.apiapp.ApiApplication.Sone.FSS;
-
 @Configuration
 @Import({
+        MetrikkRessurs.class,
         LoggRessurs.class
 })
 public class ApplicationConfig implements NaisApiApplication {


### PR DESCRIPTION
Fikk bad request fra tiltakinfo da jeg sendte inn forespørsel fra Tiltakinfo. 
Hjelper det å importere den nye ressursen inn i ApplicationConfig, eller må det gjøres mer for at applikasjonen skal skjønne forskjell på /level og /event?